### PR TITLE
Use atomic operations in NewBasic, remove overflow check and add benc…

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -1,14 +1,13 @@
 package ecs
 
 import (
-	"log"
-	"math"
 	"sync"
+	"sync/atomic"
 )
 
 var (
 	counterLock sync.Mutex
-	id_incr     uint64
+	idInc       uint64
 )
 
 // Entity is the E in Entity Component System. It belongs to any amount of
@@ -19,14 +18,7 @@ type BasicEntity struct {
 
 // NewBasic creates a new Entity with a new unique identifier - can be called across multiple goroutines
 func NewBasic() BasicEntity {
-	counterLock.Lock()
-	id_incr++
-	if id_incr >= math.MaxUint64 {
-		log.Println("Warning: id overload")
-		id_incr = 1
-	}
-	counterLock.Unlock()
-	return BasicEntity{id_incr}
+	return BasicEntity{id: atomic.AddUint64(&idInc, 1)}
 }
 
 // NewBasics creates an amount of new entities with a new unique identifier - can be called across multiple goroutines
@@ -36,12 +28,8 @@ func NewBasics(amount int) []BasicEntity {
 
 	counterLock.Lock()
 	for i := 0; i < amount; i++ {
-		id_incr++
-		if id_incr >= math.MaxUint64 {
-			log.Println("Warning: id overload")
-			id_incr = 1
-		}
-		entities[i] = BasicEntity{id_incr}
+		idInc++
+		entities[i] = BasicEntity{id: idInc}
 	}
 	counterLock.Unlock()
 

--- a/entity_test.go
+++ b/entity_test.go
@@ -188,3 +188,57 @@ func Bench(b *testing.B, preload func(), setup func(w *World)) {
 		w.Update(1 / 120) // 120 fps
 	}
 }
+
+func BenchmarkNewBasic(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewBasic()
+	}
+}
+
+func BenchmarkNewBasics1(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewBasics(1)
+	}
+}
+
+func BenchmarkNewBasic10(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 10; j++ {
+			NewBasic()
+		}
+	}
+}
+
+func BenchmarkNewBasics10(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewBasics(10)
+	}
+}
+
+func BenchmarkNewBasic100(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 100; j++ {
+			NewBasic()
+		}
+	}
+}
+
+func BenchmarkNewBasics100(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewBasics(100)
+	}
+}
+
+func BenchmarkNewBasic1000(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 1000; j++ {
+			NewBasic()
+		}
+	}
+}
+
+func BenchmarkNewBasics1000(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewBasics(1000)
+	}
+}


### PR DESCRIPTION
…hmarks.

Fixes #21.

   u@x1 ~/g/s/e/ecs> benchcmp old.txt new.txt
   benchmark               old ns/op     new ns/op     delta
   BenchmarkNewBasic-4     27.3          10.4          -61.90%

Also add benchmarks to find the breakpoint where it starts to make
sense to allocate several basic entities. On this machine, using
NewEntities is faster even for 10 entities as it only uses a single
lock as compared to 10 atomic operations.

BenchmarkNewBasic-4        	100000000	        10.5 ns/op
BenchmarkNewBasics1-4      	30000000	        42.8 ns/op
BenchmarkNewBasic10-4      	20000000	       105 ns/op
BenchmarkNewBasics10-4     	20000000	        70.3 ns/op
BenchmarkNewBasic100-4     	 1000000	      1046 ns/op
BenchmarkNewBasics100-4    	 3000000	       433 ns/op
BenchmarkNewBasic1000-4    	  200000	     10418 ns/op
BenchmarkNewBasics1000-4   	  300000	      3907 ns/op