### PR TITLE
Improve test coverage for ecs and basic race conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ branch:
     - "master"
 language: go
 go_import_path: engo.io/ecs
+script: go test -v -race ./...
 go:
 - 1.6.2

--- a/entity_test.go
+++ b/entity_test.go
@@ -169,6 +169,22 @@ func TestSortableIdentifierSlice(t *testing.T) {
 	assert.ObjectsAreEqual(e2, entities[1])
 }
 
+// TestBulkCreateBasics checks that bulk creating using NewBasics doesn't have a data race
+func TestBulkCreateBasics(t *testing.T) {
+	var e1, e2 []BasicEntity
+	entityChan := make(chan []BasicEntity)
+	cb := func(out chan<- []BasicEntity) {
+		out <- NewBasics(1000)
+	}
+
+	go cb(entityChan)
+	go cb(entityChan)
+	e1 = <-entityChan
+	e2 = <-entityChan
+	assert.Len(t, e1, 1000)
+	assert.Len(t, e2, 1000)
+}
+
 func BenchmarkIdiomatic(b *testing.B) {
 	preload := func() {}
 	setup := func(w *World) {

--- a/system_test.go
+++ b/system_test.go
@@ -1,0 +1,48 @@
+package ecs
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type PrioritizedSystem struct {
+	entities []*BasicEntity
+	priority int
+}
+
+func (p *PrioritizedSystem) Priority() int { return p.priority }
+func (*PrioritizedSystem) New(*World)      {}
+
+func (sys *PrioritizedSystem) Update(float32) {
+}
+func (*PrioritizedSystem) Remove(BasicEntity) {}
+
+// TestPrioritizedSystemsSort according to priorty (highest first)
+func TestPrioritizedSystemsSort(t *testing.T) {
+	assert := assert.New(t)
+
+	var lowPriority, highPriority *PrioritizedSystem
+	lowPriority = &PrioritizedSystem{nil, 0}
+	highPriority = &PrioritizedSystem{nil, 1}
+	var systems systems = []System{lowPriority, highPriority}
+	sort.Sort(systems)
+	assert.Equal(systems[0].(Prioritizer).Priority(), 1)
+	assert.Equal(systems[1].(Prioritizer).Priority(), 0)
+}
+
+// TestUnPrioritizedSystemsStable when sorted
+func TestUnPrioritizedSystemsStable(t *testing.T) {
+	var first, second *PrioritizedSystem
+	first = &PrioritizedSystem{nil, 0}
+	second = &PrioritizedSystem{nil, 0}
+	var systems systems = []System{first, second}
+	sort.Sort(systems)
+	sortedFirst := systems[0].(*PrioritizedSystem)
+	sortedSecond := systems[1].(*PrioritizedSystem)
+	// assert.Equal doesn't do reference comparison
+	if first != sortedFirst || second != sortedSecond {
+		t.Errorf("Sort of systems is not stable")
+	}
+}


### PR DESCRIPTION
Added tests for bulk creating of entities and to test for race conditions the NewBasics function.

Added tests for the `ecs.System`'s implementation of the `sort.Interface`, for direction and stability.