### PR TITLE
Added GetBasicEntity method for interface power

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -56,11 +56,12 @@ func (e BasicEntity) ID() uint64 {
 	return e.id
 }
 
-//By having this, All Entities, with this component, now have a GetBasicEntity Method
-//This allows system.Add functions to recieve a single interface
-//EG:
+// GetBasicEntity returns a Pointer to the BasicEntity itself
+// By having this method, All Entities containing a BasicEntity now automatically have a GetBasicEntity Method
+// This allows system.Add functions to recieve a single interface
+// EG:
 // s.AddByInterface(a interface{GetBasicEntity()*BasicEntity, GetSpaceComponent()*SpaceComponent){
-//    s.Add(a.GetBasicEntity(),a.GetSpaceComponent())
+// s.Add(a.GetBasicEntity(),a.GetSpaceComponent())
 //}
 func (e *BasicEntity) GetBasicEntity() *BasicEntity {
 	return e

--- a/entity.go
+++ b/entity.go
@@ -56,6 +56,16 @@ func (e BasicEntity) ID() uint64 {
 	return e.id
 }
 
+//By having this, All Entities, with this component, now have a GetBasicEntity Method
+//This allows system.Add functions to recieve a single interface
+//EG:
+// s.AddByInterface(a interface{GetBasicEntity()*BasicEntity, GetSpaceComponent()*SpaceComponent){
+//    s.Add(a.GetBasicEntity(),a.GetSpaceComponent())
+//}
+func (e *BasicEntity) GetBasicEntity() *BasicEntity {
+	return e
+}
+
 // Len returns the length of the underlying slice
 // part of the sort.Interface
 func (is IdentifierSlice) Len() int {


### PR DESCRIPTION
GetBasicEntity()   simply returns itself as an object, so that the containing component automatically fulfils the interface{GetBasicEntity() *BasicEntity}

If all components also implement a method similar to this, then we can make adding objects to systems a whole lot simpler.

instead of
```
sys.Add(ob.BasicEntity,ob.SpaceComponent,ob.OtherComponent) 
```
The engine user can now write
```
sys.AddByInterface(ob)
```
If an object has duplicated components for some reason, these can still be added using the old system.

My proposal is simply to have the AddByInterface() method call the Add method with the respective parts.
