### PR TITLE
added systems to be able to be automatically populated by the world

### DIFF
--- a/system.go
+++ b/system.go
@@ -17,6 +17,16 @@ type System interface {
 	Remove(e BasicEntity)
 }
 
+// SystemAddByInterfacer is a system that also implements the AddByInterface method
+type SystemAddByInterfacer interface {
+	System
+
+	// AddByInterface allows you to automatically add entities based on the
+	// interfaces that the entity implements. It should add the entity passed
+	// as o to the system after casting it to the correct interface.
+	AddByInterface(o interface{})
+}
+
 // Prioritizer specifies the priority of systems.
 type Prioritizer interface {
 	// Priority indicates the order in which Systems should be executed per

--- a/world.go
+++ b/world.go
@@ -1,13 +1,15 @@
 package ecs
 
 import (
+	"reflect"
 	"sort"
 )
 
 // World contains a bunch of Entities, and a bunch of Systems. It is the
 // recommended way to run ecs.
 type World struct {
-	systems systems
+	systems      systems
+	sysIn, sysEx map[reflect.Type]reflect.Type
 }
 
 // AddSystem adds the given System to the World, sorted by priority.
@@ -18,6 +20,59 @@ func (w *World) AddSystem(system System) {
 
 	w.systems = append(w.systems, system)
 	sort.Sort(w.systems)
+}
+
+// AddSystemInterface adds a system to the world, but also adds a filter that allows
+// automatic adding of entities that match the provided in interface, and excludes any
+// that match the provided ex interface, even if they also match in. in and ex must be
+// pointers to the interface or else this panics.
+func (w *World) AddSystemInterface(sys SystemAddByInterfacer, in interface{}, ex interface{}) {
+	w.AddSystem(sys)
+
+	if w.sysIn == nil {
+		w.sysIn = make(map[reflect.Type]reflect.Type)
+	}
+
+	w.sysIn[reflect.TypeOf(sys)] = reflect.TypeOf(in).Elem()
+
+	if ex == nil {
+		return
+	}
+
+	if w.sysEx == nil {
+		w.sysEx = make(map[reflect.Type]reflect.Type)
+	}
+
+	w.sysEx[reflect.TypeOf(sys)] = reflect.TypeOf(ex).Elem()
+}
+
+// AddEntity adds the entity to all systems that have been added via
+// AddSystemInterface. If the system was added via AddSystem the entity will not be
+// added to it.
+func (w *World) AddEntity(e Identifier) {
+	if w.sysIn == nil {
+		w.sysIn = make(map[reflect.Type]reflect.Type)
+	}
+	if w.sysEx == nil {
+		w.sysEx = make(map[reflect.Type]reflect.Type)
+	}
+	for _, system := range w.systems {
+		sys, ok := system.(SystemAddByInterfacer)
+		if !ok {
+			return
+		}
+		if ex, not := w.sysEx[reflect.TypeOf(sys)]; not {
+			if reflect.TypeOf(e).Implements(ex) {
+				continue
+			}
+		}
+		if in, ok := w.sysIn[reflect.TypeOf(sys)]; ok {
+			if reflect.TypeOf(e).Implements(in) {
+				s := sys.(SystemAddByInterfacer)
+				s.AddByInterface(e)
+			}
+		}
+	}
 }
 
 // Systems returns the list of Systems managed by the World.


### PR DESCRIPTION
Adds a SystemAddByInterfacer that allows systems to include a function AddByInterface(o interface{}) that can then be used so the world can automatically add entities to the proper systems without having to go through the type switch and adding the components manually. This allows users to easily change entities without having to add it to every system properly, which can get unwieldy in games with lots of entities and systems. Even more than, say, five systems and ten entities can be a hassle.