### PR TITLE
Race Conditions detected on the World struct

### DIFF
--- a/world.go
+++ b/world.go
@@ -3,17 +3,21 @@ package ecs
 import (
 	"reflect"
 	"sort"
+	"sync"
 )
 
 // World contains a bunch of Entities, and a bunch of Systems. It is the
 // recommended way to run ecs.
 type World struct {
+	*sync.RWMutex
 	systems      systems
 	sysIn, sysEx map[reflect.Type]reflect.Type
 }
 
 // AddSystem adds the given System to the World, sorted by priority.
 func (w *World) AddSystem(system System) {
+	w.Lock()
+	defer w.Unlock()
 	if initializer, ok := system.(Initializer); ok {
 		initializer.New(w)
 	}
@@ -29,6 +33,8 @@ func (w *World) AddSystem(system System) {
 func (w *World) AddSystemInterface(sys SystemAddByInterfacer, in interface{}, ex interface{}) {
 	w.AddSystem(sys)
 
+	w.Lock()
+	defer w.Unlock()
 	if w.sysIn == nil {
 		w.sysIn = make(map[reflect.Type]reflect.Type)
 	}
@@ -50,12 +56,16 @@ func (w *World) AddSystemInterface(sys SystemAddByInterfacer, in interface{}, ex
 // AddSystemInterface. If the system was added via AddSystem the entity will not be
 // added to it.
 func (w *World) AddEntity(e Identifier) {
+	w.Lock()
 	if w.sysIn == nil {
 		w.sysIn = make(map[reflect.Type]reflect.Type)
 	}
 	if w.sysEx == nil {
 		w.sysEx = make(map[reflect.Type]reflect.Type)
 	}
+	w.Unlock()
+
+	w.RLock()
 	for _, system := range w.systems {
 		sys, ok := system.(SystemAddByInterfacer)
 		if !ok {
@@ -68,10 +78,14 @@ func (w *World) AddEntity(e Identifier) {
 		}
 		if in, ok := w.sysIn[reflect.TypeOf(sys)]; ok {
 			if reflect.TypeOf(e).Implements(in) {
+				w.RUnlock()
 				sys.AddByInterface(e)
+				w.RLock()
 			}
 		}
 	}
+	w.RUnlock()
+
 }
 
 // Systems returns the list of Systems managed by the World.
@@ -82,14 +96,22 @@ func (w *World) Systems() []System {
 // Update updates each System managed by the World. It is invoked by the engine
 // once every frame, with dt being the duration since the previous update.
 func (w *World) Update(dt float32) {
+	w.RLock()
 	for _, system := range w.Systems() {
+		w.RUnlock()
 		system.Update(dt)
+		w.RLock()
 	}
+	w.RUnlock()
 }
 
 // RemoveEntity removes the entity across all systems.
 func (w *World) RemoveEntity(e BasicEntity) {
+	w.RLock()
 	for _, sys := range w.systems {
+		w.RUnlock()
 		sys.Remove(e)
+		w.RLock()
 	}
+	w.RUnlock()
 }

--- a/world.go
+++ b/world.go
@@ -97,6 +97,8 @@ func (w *World) AddEntity(e Identifier) {
 
 // Systems returns the list of Systems managed by the World.
 func (w *World) Systems() []System {
+	mu.RLock()
+	defer mu.RUnlock()
 	return w.systems
 }
 

--- a/world.go
+++ b/world.go
@@ -85,7 +85,7 @@ func (w *World) AddEntity(e Identifier) {
 		}
 		if in, ok := w.sysIn[reflect.TypeOf(sys)]; ok {
 			if reflect.TypeOf(e).Implements(in) {
-				w.Mu.RUnlock()
+				mu.RUnlock()
 				sys.AddByInterface(e)
 				mu.RLock()
 			}

--- a/world.go
+++ b/world.go
@@ -18,14 +18,18 @@ type World struct {
 
 // AddSystem adds the given System to the World, sorted by priority.
 func (w *World) AddSystem(system System) {
-	mu.Lock()
-	defer mu.Unlock()
+	mu.RLock()
 	if initializer, ok := system.(Initializer); ok {
+		mu.RUnlock()
 		initializer.New(w)
+		mu.RLock()
 	}
+	mu.RUnlock()
 
+	mu.Lock()
 	w.systems = append(w.systems, system)
 	sort.Sort(w.systems)
+	mu.Unlock()
 }
 
 // AddSystemInterface adds a system to the world, but also adds a filter that allows


### PR DESCRIPTION
When I build the game using the `-race` flag:

```bash

go build -race main.go

```

and run it on a different goroutine (I'm using a server to add entities to the World) the compiler detects **race conditions**.

This PR adds an `RWMutex` to the `ecs` package to sync the state of the `world`