### PR TITLE
Allow more than one interface in `World.AddSystemInterface` in and ex.

### DIFF
--- a/world.go
+++ b/world.go
@@ -32,7 +32,10 @@ func (w *World) AddSystemInterface(sys SystemAddByInterfacer, in interface{}, ex
 	if w.sysIn == nil {
 		w.sysIn = make(map[reflect.Type][]reflect.Type)
 	}
-	
+
+	if reflect.TypeOf(in) != reflect.TypeOf([]interface{}{}) {
+		in = []interface{}{in}
+	}
 	for _, v := range in.([]interface{}) {
 		w.sysIn[reflect.TypeOf(sys)] = append(w.sysIn[reflect.TypeOf(sys)], reflect.TypeOf(v).Elem())
 	}
@@ -45,9 +48,13 @@ func (w *World) AddSystemInterface(sys SystemAddByInterfacer, in interface{}, ex
 		w.sysEx = make(map[reflect.Type][]reflect.Type)
 	}
 
+	if reflect.TypeOf(ex) != reflect.TypeOf([]interface{}{}) {
+		ex = []interface{}{ex}
+	}
 	for _, v := range ex.([]interface{}) {
 		w.sysEx[reflect.TypeOf(sys)] = append(w.sysEx[reflect.TypeOf(sys)], reflect.TypeOf(v).Elem())
 	}
+	// w.sysEx[reflect.TypeOf(sys)] = reflect.TypeOf(ex).Elem()
 }
 
 // AddEntity adds the entity to all systems that have been added via
@@ -65,6 +72,7 @@ func (w *World) AddEntity(e Identifier) {
 		if !ok {
 			continue
 		}
+
 		if ex, not := w.sysEx[reflect.TypeOf(sys)]; not {
 			for _, t := range ex {
 				if reflect.TypeOf(e).Implements(t) {

--- a/world.go
+++ b/world.go
@@ -33,7 +33,7 @@ func (w *World) AddSystemInterface(sys SystemAddByInterfacer, in interface{}, ex
 		w.sysIn = make(map[reflect.Type][]reflect.Type)
 	}
 
-	if reflect.TypeOf(in).AssignableTo(reflect.TypeOf([]interface{}{})) {
+	if !reflect.TypeOf(in).AssignableTo(reflect.TypeOf([]interface{}{})) {
 		in = []interface{}{in}
 	}
 	for _, v := range in.([]interface{}) {

--- a/world_test.go
+++ b/world_test.go
@@ -1,0 +1,86 @@
+package ecs
+
+import (
+	"testing"
+)
+
+func TestWorld_AddSystemInterface(t *testing.T) {
+	type foo interface {
+		a() string
+	}
+	var fooInstance *foo
+	type args struct {
+		sys SystemAddByInterfacer
+		in  interface{}
+		ex  interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		// {"adds individual interface", args{}},
+		{"adds multiple interfaces", args{nil, fooInstance, nil}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := new(World)
+			w.AddSystemInterface(tt.args.sys, tt.args.in, tt.args.ex)
+		})
+	}
+}
+
+type simpleEntity struct {
+	BasicEntity
+}
+type entent struct {
+	*BasicEntity
+}
+type simpleSystem struct {
+	entities []entent
+}
+
+func (s *simpleSystem) Add(b *BasicEntity) {
+	s.entities = append(s.entities, entent{b})
+}
+
+func (s *simpleSystem) AddByInterface(i Identifier) {
+	obj, ok := i.(BasicFace)
+	if ok {
+		s.Add(obj.GetBasicEntity())
+	}
+}
+
+func (s *simpleSystem) Remove(b BasicEntity) {
+}
+
+func (s *simpleSystem) Update(dt float32) {
+}
+func TestWorld_AddEntity(t *testing.T) {
+
+	type args struct {
+		systems []SystemAddByInterfacer
+		e       Identifier
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{"works with multiple interfaces", args{
+			systems: []SystemAddByInterfacer{&simpleSystem{}},
+			e:       &simpleEntity{NewBasic()},
+		},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := new(World)
+			sys := new(simpleSystem)
+			var face *BasicFace
+			w.AddSystemInterface(sys, []interface{}{face}, nil)
+			w.AddEntity(tt.args.e)
+			if len(sys.entities) == 0 {
+				t.Error(len(sys.entities))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements the changes discussed in issue #37.