### PR TITLE
moved BasicFace from the tests to the actual library

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -133,3 +133,9 @@ func (is IdentifierSlice) Less(i, j int) bool {
 func (is IdentifierSlice) Swap(i, j int) {
 	is[i], is[j] = is[j], is[i]
 }
+
+// BasicFase is an interface that BasicEntity and entities containing
+// a BasicEntity implement.
+type BasicFace interface {
+	GetBasicEntity() *BasicEntity
+}

--- a/entity_test.go
+++ b/entity_test.go
@@ -128,10 +128,6 @@ func (sys *MySystemTwo) AddByInterface(o Identifier) {
 	sys.Add(obj.GetBasicEntity(), obj.GetMyComponent2())
 }
 
-type BasicFace interface {
-	GetBasicEntity() *BasicEntity
-}
-
 type MyEntity1 struct {
 	BasicEntity
 	MyComponent1


### PR DESCRIPTION
This will allow anyone to use it without having to import engo itself! Fixes #45.